### PR TITLE
Remove anonymous function error

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -273,4 +273,4 @@ function init() {
     prefix = await browser.runtime.sendMessage('prefix-request');
 
     init();
-})();
+});


### PR DESCRIPTION
I am constantly getting an error from the browser extension
![Extensions - Google Chrome 8_28_2020 8_47_26 PM](https://user-images.githubusercontent.com/66492208/91625785-c3922d00-e96f-11ea-91f8-83b4d4544864.png)

So I removed the extra set of parenthesis to fix it
