### PR TITLE
Fix copylibs script on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A browser extension for simplifying the mod & helper workflow on Mojang's bug tracker Mojira",
   "main": "main.js",
   "scripts": {
-    "copylibs": "rm -rf lib && mkdir lib && cp -r node_modules/webextension-polyfill/dist/* ./lib",
+    "copylibs": "(rm -rf lib || rmdir /Q /S lib || echo>NUL) && mkdir lib && (cp -r node_modules/webextension-polyfill/dist/* ./lib || copy node_modules\\webextension-polyfill\\dist\\* .\\lib)",
     "build": "npm run copylibs && web-ext build -o",
     "lint": "npm run copylibs && web-ext lint --self-hosted"
   },


### PR DESCRIPTION
This is _highly_ jank, but it now runs correctly on both Windows and Linux (well, I tested with cygwin).  On Windows, the following appears in the console, but it does work successfully:

```
'rm' is not recognized as an internal or external command,
operable program or batch file.
'cp' is not recognized as an internal or external command,
operable program or batch file.
node_modules\webextension-polyfill\dist\browser-polyfill.js
node_modules\webextension-polyfill\dist\browser-polyfill.js.map
node_modules\webextension-polyfill\dist\browser-polyfill.min.js
node_modules\webextension-polyfill\dist\browser-polyfill.min.js.map
        4 file(s) copied.
```

The `echo>NUL` part is needed because the `lib` directory might not exist, in which case `rmdir` will fail.  It's the closest equivalent to `true` that I could find.  (`rm -rf` does not have that issue; it will still be successful if `lib` does not exist.)

Ideally, there would be a proper cross-platform way to copy `browser-polyfill.min.js` into `lib`, but I couldn't find a good way of doing it.