### PR TITLE
Fix text area not resizing properly after using shortcut

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -242,6 +242,9 @@ async function replaceText(textArea, project) {
         } else {
             setCaretToPos(textArea, cursorPos);
         }
+
+        // Fix text area not resizing properly
+        textArea.dispatchEvent(new KeyboardEvent('keyup'));
     }
 }
 


### PR DESCRIPTION
Fixes #19 by firing a fake keyup event after replacing a shortcut.