### PR TITLE
Don't use innerHTML for popup

### DIFF
--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -1,4 +1,4 @@
-import { getPopupMessage } from "../util/settings.js";
+import { getPopupMessage } from '../util/settings.js';
 
 document.querySelector('.dismiss-button').addEventListener('click', () => {
     browser.browserAction.setPopup({popup: ''});
@@ -6,14 +6,44 @@ document.querySelector('.dismiss-button').addEventListener('click', () => {
     window.close();
 });
 
+const defaultPopupMessage = '*Error: Could not retreive popup message.*\n'
+    + 'Internal extension communication is not possible! Try disabling the extension and enabling it again.\n'
+    + 'If the issue persists, try restarting your browser.';
+
 (async () => {
+    let popupMessage = '';
+
     try {
-        document.querySelector('#popupMessage').innerHTML = await getPopupMessage();
+        popupMessage = await getPopupMessage();
     } catch (err) {
-        document.querySelector('#popupMessage').innerHTML = '<b>Error: Could not retreive popup message.</b><br>'
-            + 'Internal extension communication is not possible! Try disabling the extension and enabling it again.<br>'
-            + 'If the issue persists, try restarting your browser.<br>'
-            + err.message;
+        popupMessage = defaultPopupMessage + '\n' + err.message;
         console.error(err);
     }
+
+    document.querySelector('#popupMessage').textContent = '';
+    htmlifyLineBreaks(popupMessage).forEach(
+        elem => document.querySelector('#popupMessage').append(elem)
+    );
 })();
+
+/**
+ * Splits up a string into multiple paragraphs (along line breaks \n).
+ * @param {string} input The string that should be split up
+ */
+function htmlifyLineBreaks(input) {
+    const lines = input.split('\n');
+    const elements = [];
+    lines.forEach((elem, i) => {
+        if (/^\*(.+)\*$/.test(elem)) {
+            const element = document.createElement('b');
+            element.textContent = elem.match(/^\*(.+)\*$/)[1];
+            elements.push(element);
+        } else {
+            elements.push(document.createTextNode(elem))
+        }
+        if (i < lines.length - 1) {
+            elements.push(document.createElement('br'));
+        }
+    });
+    return elements;
+}

--- a/src/util/messages.js
+++ b/src/util/messages.js
@@ -61,16 +61,24 @@ export function checkForUpdates(force = false) {
                                     loadMessages(httpRequest.responseText);
                                     await setLastUpdate();
                                     await setLastCachedMessages(httpRequest.responseText);
-                                    await showSuccessBadge('Helper messages have been updated.<br>You may need to reload open tabs in order for the change to take effect.');
+                                    await showSuccessBadge(
+                                        'Helper messages have been updated.\n'
+                                        + 'You may need to reload open tabs in order for the change to take effect.'
+                                    );
                                     await initMessages();
                                 } catch (err) {
-                                    await showErrorBadge('An error occurred because the messages are invalid JSON.');
+                                    await showErrorBadge(
+                                        'An error occurred because the messages are invalid JSON.'
+                                    );
                                 }
                             } else {
                                 setTimeout(async () => await hideBadge(), 1000);
                             }
                         } else {
-                            await showErrorBadge(`An error occurred while trying to check whether the helper messages were updated.<br>The server returned status code ${httpRequest.status} ${httpRequest.statusText}.`);
+                            await showErrorBadge(
+                                'An error occurred while trying to check whether the helper messages were updated.\n'
+                                + `The server returned status code ${httpRequest.status} ${httpRequest.statusText}.`
+                            );
                         }
                         resolve();
                     }
@@ -98,7 +106,9 @@ export async function getMessages() {
     try {
         await initMessages();
     } catch {
-        await showErrorBadge('An error occurred because the messages are invalid JSON.');
+        await showErrorBadge(
+            'An error occurred because the messages are invalid JSON.'
+        );
     }
     return messageDefinitions;
 }

--- a/src/util/settings.js
+++ b/src/util/settings.js
@@ -169,8 +169,8 @@ export async function setPopupMessage(popupMessage) {
 export async function getPopupMessage() {
     return await getFromStorage(
         'popupMessage',
-        '<b>Error: Could not load popup message.</b><br>'
-            + 'Internal extension communication is not possible! Try disabling the extension and enabling it again.<br>'
+        '*Error: Could not load popup message.*\n'
+            + 'Internal extension communication is not possible! Try disabling the extension and enabling it again.\n'
             + 'If the issue persists, try restarting your browser.'
     );
 }


### PR DESCRIPTION
The addon signing process doens't like `innerHTML` (for a good reason), so let's replace the HTML with a custom simplified markdown-like format (because why not).