### PR TITLE
Add stack trace to error messages and improve popup css

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -29,6 +29,7 @@ import { getAutoUpdateInterval, getPrefix, setPopupMessage } from './util/settin
             case 'prefix-request':
                 return getPrefix();
             case 'show-error':
+                console.error(`Received error message: ${ message.errorMessage }`);
                 await showErrorBadge(message.errorMessage);
                 return;
         }

--- a/src/content.js
+++ b/src/content.js
@@ -96,8 +96,12 @@ function getDropdownList(textArea, project) {
         messageItem.append(shortcutInfo);
 
         messageItem.addEventListener('click', async event => {
-            var shortcut = event.target.getAttribute('data-mojira-helper-message');
-            await insertText(textArea, shortcut, project);
+            try {
+                var shortcut = event.target.getAttribute('data-mojira-helper-message');
+                await insertText(textArea, shortcut, project);
+            } catch (error) {
+                sendErrorMessage(error);
+            }
         });
 
         var messageDropdownItem = document.createElement('li');
@@ -207,8 +211,12 @@ function modifyWikifield(element, project, editorCount) {
         textArea.classList.add('mojira-helper-messages-textarea-shortcut-only');
         
         setTimeout(() => {
-            if (addDropdownToWikifield(element, textArea, project, editorCount)) {
-                textArea.classList.remove('mojira-helper-messages-textarea-shortcut-only');
+            try {
+                if (addDropdownToWikifield(element, textArea, project, editorCount)) {
+                    textArea.classList.remove('mojira-helper-messages-textarea-shortcut-only');
+                }
+            } catch (error) {
+                sendErrorMessage(error);
             }
         }, 1000);
     }
@@ -311,12 +319,7 @@ function init() {
                     editorCount++
                 );
             } catch (error) {
-                console.error(error);
-                try {
-                    await browser.runtime.sendMessage({id: 'show-error', errorMessage: error.message});
-                } catch (err) {
-                    console.error(err);
-                }
+                await sendErrorMessage(error);
             }
         });
     }, 1000);
@@ -328,12 +331,7 @@ function init() {
                 await replaceText(element, element.getAttribute('helper-messages-project'));
             }
         } catch (error) {
-            console.error(error);
-            try {
-                await browser.runtime.sendMessage({id: 'show-error', errorMessage: error.message});
-            } catch (err) {
-                console.error(err);
-            }
+            await sendErrorMessage(error);
         }
     });
 }
@@ -347,12 +345,7 @@ function init() {
         prefix = await browser.runtime.sendMessage({id: 'prefix-request'});
 
         init();
-    } catch (err) {
-        console.error(err);
-        try {
-            await browser.runtime.sendMessage({id: 'show-error', errorMessage: err.message});
-        } catch (err2) {
-            console.error('Error while reporting error message:', err2);
-        }
+    } catch (error) {
+        await sendErrorMessage(error);
     }
 })();

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -5,20 +5,39 @@
         <script type="module" src="/lib/browser-polyfill.min.js"></script>
         <script type="module" src="./popup.js"></script>
         <style>
+            body {
+                min-width: 400px;
+                max-width: 800px;
+                max-height: 600px;
+            }
+
             .panel {
                 margin: 2em;
                 font-family: sans-serif;
                 text-align: center;
             }
+
+            #popupMessage {
+                text-align: center;
+                margin-bottom: 2em;
+            }
+
+            pre {
+                overflow-x: auto;
+                border: 1px solid #aaa;
+                border-radius: 3px;
+                padding: 1em;
+                background-color: #eee;
+            }
         </style>
     </head>
     <body>
         <div class="panel browser-style">
-            <span id="popupMessage">
+            <div id="popupMessage">
                 <b>Error: Popup message was not changed from default.</b><br>
                 Internal extension communication is not possible! Try disabling the extension and enabling it again.<br>
                 If the issue persists, try restarting your browser.
-            </span><br><br>
+            </div>
             <button class="browser-style dismiss-button">Dismiss</button>
         </div>
     </body>

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -33,15 +33,30 @@ const defaultPopupMessage = '*Error: Could not retreive popup message.*\n'
 function htmlifyLineBreaks(input) {
     const lines = input.split('\n');
     const elements = [];
+    let inBlock = false;
     lines.forEach((elem, i) => {
         if (/^\*(.+)\*$/.test(elem)) {
             const element = document.createElement('b');
             element.textContent = elem.match(/^\*(.+)\*$/)[1];
             elements.push(element);
+        } else if (/^```$/.test(elem)) {
+            inBlock = !inBlock;
+            if (inBlock) {
+                const element = document.createElement('pre');
+                elements.push(element);
+            } else {
+                /** @type {HTMLPreElement} */
+                const block = elements[elements.length - 1];
+                block.textContent = block.textContent.replace(/\n+$/, '');
+            }
+        } else if (inBlock) {
+            /** @type {HTMLPreElement} */
+            const block = elements[elements.length - 1];
+            block.textContent += elem + '\n';
         } else {
             elements.push(document.createTextNode(elem))
         }
-        if (i < lines.length - 1) {
+        if (i < lines.length - 1 && !inBlock) {
             elements.push(document.createElement('br'));
         }
     });

--- a/src/util/util.js
+++ b/src/util/util.js
@@ -27,3 +27,20 @@ function setSelectionRange(input, selectionStart, selectionEnd) {
 function setCaretToPos(input, pos) {
     setSelectionRange(input, pos, pos);
 }
+
+/**
+ * Sends an error message to background.js, so that it can be displayed to the user.
+ * @param {Error} error The error that should be sent
+ */
+async function sendErrorMessage(error) {
+    console.error(error);
+    try {
+        let errorMessage = `*${ error.message }*`;
+        if (error.stack) {
+            errorMessage += '\n```\n' + error.stack + '\n```';
+        }
+        await browser.runtime.sendMessage({id: 'show-error', errorMessage});
+    } catch (err) {
+        console.error('Error while reporting error message:', err);
+    }
+}


### PR DESCRIPTION
* When an error message is thrown in `content.js`, the stack trace now is shown as well in the popup
* Added formatting for code blocks to the watered-down popup markup format (because why not)
* Improved CSS in popup
  * This also fixes #40 along the way
* Additionally log errors in addon console in case things go wrong