### PR TITLE
Add postpone button warning/disabling option

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1,6 +1,6 @@
 import { showErrorBadge } from './util/badge.js';
 import { getMessages, checkForUpdates } from './util/messages.js';
-import { getAutoUpdateInterval, getPrefix, setPopupMessage } from './util/settings.js';
+import { getAutoUpdateInterval, getPostponeAction, getPrefix, setPopupMessage } from './util/settings.js';
 
 (async () => {
     await setPopupMessage(undefined);
@@ -25,9 +25,11 @@ import { getAutoUpdateInterval, getPrefix, setPopupMessage } from './util/settin
     browser.runtime.onMessage.addListener(async message => {
         switch (message.id) {
             case 'messages-request':
-                return getMessages();
+                return await getMessages();
             case 'prefix-request':
-                return getPrefix();
+                return await getPrefix();
+            case 'postponeaction-request':
+                return await getPostponeAction();
             case 'show-error':
                 console.error(`Received error message: ${ message.errorMessage }`);
                 await showErrorBadge(message.errorMessage);

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -62,6 +62,13 @@
                 <input class=browser-style id=prefix name=prefix type=text>
             </div>
 
+            <div class="group browser-style">
+                <label for=postpone>Postpone button</label><br>
+                <input id=postponeHide name=postpone type=radio><label for=postponeHide>Hide the Postpone button</label><br>
+                <input id=postponeWarn name=postpone type=radio><label for=postponeWarn>Show a warning when clicking the Postpone button</label><br>
+                <input id=postponeNone name=postpone type=radio><label for=postponeNone>Postpone the issue immediately when clicking the Postpone button</label><br>
+            </div>
+
             <div class=group>
                 <b>Select messages source</b>
             </div>

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -15,7 +15,9 @@ import {
     setCustomMessages,
     getLastUpdateCheck,
     getLastUpdate,
-    getLastCachedMessages
+    getLastCachedMessages,
+    getPostponeAction,
+    setPostponeAction
 } from '../util/settings.js';
 import { checkForUpdates } from '../util/messages.js';
 
@@ -29,6 +31,21 @@ async function init() {
     document.querySelector('#prefix').value = await getPrefix();
     document.querySelector('#prefix').addEventListener('change', async event => {        
         await setPrefix(event.target.value);
+    });
+
+    document.querySelector('#postponeHide').checked = await getPostponeAction() === 'hide';
+    document.querySelector('#postponeHide').addEventListener('click', async () => {
+        await setPostponeAction('hide');
+    });
+    
+    document.querySelector('#postponeWarn').checked = await getPostponeAction() === 'warn';
+    document.querySelector('#postponeWarn').addEventListener('click', async () => {
+        await setPostponeAction('warn');
+    });
+    
+    document.querySelector('#postponeNone').checked = await getPostponeAction() === 'none';
+    document.querySelector('#postponeNone').addEventListener('click', async () => {
+        await setPostponeAction('none');
     });
 
     document.querySelector(`#${ await getMessageSource() }`).checked = true;

--- a/src/util/settings.js
+++ b/src/util/settings.js
@@ -69,6 +69,20 @@ export async function setPrefix(prefix) {
 }
 
 /**
+ * @returns {Promise<'hide' | 'warn' | 'none'>}
+ */
+export async function getPostponeAction() {
+    return await getFromStorage('postponeAction', 'warn');
+}
+
+/**
+ * @param {Promise<'hide' | 'warn' | 'none'>} postponeAction How to handle the postpone button
+ */
+export async function setPostponeAction(postponeAction) {
+    await saveToStorage({postponeAction});
+}
+
+/**
  * @returns {Promise<'remote' | 'custom'>} Where the helper messages come from
  */
 export async function getMessageSource() {


### PR DESCRIPTION
Closes #33.

Added a new option which allows you to either completely hide the Postpone button, show a warning when clicking it, or keep the default behaviour.