### PR TITLE
List changes to helper messages after update

### DIFF
--- a/src/options/options.html
+++ b/src/options/options.html
@@ -19,7 +19,7 @@
                 margin-bottom: 1em;
             }
 
-            textarea, #url {
+            textarea, .textinput {
                 width: 100%;
             }
 
@@ -59,7 +59,7 @@
             
             <div class="group browser-style">
                 <label for=prefix>Shortcut prefix</label><br>
-                <input class=browser-style id=prefix name=prefix type=text>
+                <input class="browser-style textinput" id=prefix name=prefix type=text>
             </div>
 
             <div class="group browser-style">
@@ -108,6 +108,21 @@
                 <textarea class=browser-style id=custom-messages></textarea><br>
                 <button class=browser-style id=save-custom-messages>Save custom messages</button><br>
                 <small id="custom-messages-feedback" class="hidden">test</small>
+            </div>
+
+            <div class=group>
+                <b>Advanced settings</b>
+            </div>
+
+            <div class="group browser-style">
+                <input id=commit-updates name=commit-updates type=checkbox>
+                <label for=commit-updates>Enable commit updates</label><br>
+            </div>
+            <div id=commit-subpanel class="subpanel browser-style">
+                <div class="group browser-style">
+                    <label for=commit-url>Commits URL</label><br>
+                    <input class="browser-style textinput" id=commit-url name=commit-url type=text>
+                </div>
             </div>
         </div>
     </body>

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -17,7 +17,11 @@ import {
     getLastUpdate,
     getLastCachedMessages,
     getPostponeAction,
-    setPostponeAction
+    setPostponeAction,
+    getCommitUpdatesEnabled,
+    getCommitUrl,
+    setCommitUpdatesEnabled,
+    setCommitUrl
 } from '../util/settings.js';
 import { checkForUpdates } from '../util/messages.js';
 
@@ -97,6 +101,16 @@ async function init() {
         } catch (err) {
             feedback.textContent = `Error when saving custom messages: ${err}`;
         }
+    });
+
+    document.querySelector('#commit-updates').checked = await getCommitUpdatesEnabled();
+    document.querySelector('#commit-updates').addEventListener('click', async () => {
+        setCommitUpdatesEnabled(document.querySelector('#commit-updates').checked);
+    });
+
+    document.querySelector('#commit-url').value = await getCommitUrl();
+    document.querySelector('#commit-url').addEventListener('change', async () => {
+        setCommitUrl(document.querySelector('#commit-url').value);
     });
 }
 

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
+        <base target="_blank"/>
         <meta charset="utf-8"/>
         <script type="module" src="/lib/browser-polyfill.min.js"></script>
         <script type="module" src="./popup.js"></script>
@@ -28,6 +29,19 @@
                 border-radius: 3px;
                 padding: 1em;
                 background-color: #eee;
+            }
+
+            a {
+                color: #2e72cc;
+                text-decoration: none;
+                transition: color 0.1s;
+            }
+            a:hover {
+                color: #2ecc72;
+            }
+            li {
+                margin: 0.5em;
+                text-align: left;
             }
         </style>
     </head>

--- a/src/util/settings.js
+++ b/src/util/settings.js
@@ -174,6 +174,28 @@ export async function getCustomMessages() {
 }
 
 /**
+ * @param {boolean} commitUpdatesEnabled Whether commit updates should be enabled
+ */
+export async function setCommitUpdatesEnabled(commitUpdatesEnabled) {
+    await saveToStorage({commitUpdatesEnabled});
+}
+
+export async function getCommitUpdatesEnabled() {
+    return await getFromStorage('commitUpdatesEnabled', true);
+}
+
+/**
+ * @param {string} commitUrl The url to the commits JSON file
+ */
+export async function setCommitUrl(commitUrl) {
+    await saveToStorage({commitUrl});
+}
+
+export async function getCommitUrl() {
+    return await getFromStorage('commitUrl', 'https://api.github.com/repos/mojira/helper-messages/commits');
+}
+
+/**
  * @param {string} popupMessage The current popup message
  */
 export async function setPopupMessage(popupMessage) {
@@ -187,4 +209,26 @@ export async function getPopupMessage() {
             + 'Internal extension communication is not possible! Try disabling the extension and enabling it again.\n'
             + 'If the issue persists, try restarting your browser.'
     );
+}
+
+/**
+ * @param {string} commit The sha of the last commit
+ */
+export async function setLastCommit(lastCommit) {
+    await saveToStorage({lastCommit});
+}
+
+export async function getLastCommit() {
+    return await getFromStorage('lastCommit', 'none');
+}
+
+/**
+ * @param {string} lastCommits The JSON representation of the last commits
+ */
+export async function setLastCommits(lastCommits) {
+    await saveToStorage({lastCommits});
+}
+
+export async function getLastCommits() {
+    return await getFromStorage('lastCommits', '[]');
 }


### PR DESCRIPTION
Fixes #21.

Whenever the cached helper messages have been updated, the extension now lists all the commits since the last update in the popup.

![grafik](https://user-images.githubusercontent.com/12451842/104529686-938bb380-560a-11eb-91fa-1e7fedf548d2.png)