### PR TITLE
Added autodisable check for non helpers/mods (as per #55)

### DIFF
--- a/src/content/content.js
+++ b/src/content/content.js
@@ -40,11 +40,6 @@ function init() {
     handlePostponeButton();
 }
 
-function isVolunteerUser() {
-    let opsbar = document.querySelector('div#opsbar-opsbar-transitions');
-    return opsbar && opsbar.children.length > 0;
-}
-
 (async () => {
     try {
         const messagesReply = await browser.runtime.sendMessage({id: 'messages-request'});

--- a/src/content/content.js
+++ b/src/content/content.js
@@ -11,7 +11,8 @@ function init() {
                 modifyWikifield(
                     element,
                     element.getAttribute('issue-key').split('-')[0].toLowerCase(),
-                    editorCount++
+                    editorCount++,
+                    document.querySelector('div#opsbar-opsbar-transitions') == null
                 );
             } catch (error) {
                 await sendErrorMessage(error);

--- a/src/content/content.js
+++ b/src/content/content.js
@@ -12,7 +12,7 @@ function init() {
                     element,
                     element.getAttribute('issue-key').split('-')[0].toLowerCase(),
                     editorCount++,
-                    document.querySelector('div#opsbar-opsbar-transitions') == null
+                    !isVolunteerUser()
                 );
             } catch (error) {
                 await sendErrorMessage(error);
@@ -38,6 +38,11 @@ function init() {
     });
 
     handlePostponeButton();
+}
+
+function isVolunteerUser() {
+    let opsbar = document.querySelector('div#opsbar-opsbar-transitions');
+    return opsbar && opsbar.children.length > 0;
 }
 
 (async () => {

--- a/src/content/dropdown.js
+++ b/src/content/dropdown.js
@@ -88,6 +88,7 @@ function getMessageButton(editorCount, disabled) {
     );
     if (disabled) {
         messageButton.setAttribute('disabled', true);
+        messageButton.classList.add('mojira-helper-messages-button-disabled');
     }
     messageButton.href = '#';
     messageButton.title = title;
@@ -148,7 +149,7 @@ function modifyWikifield(element, project, editorCount, disabled) {
     element.classList.add('mojira-helper-messages-field');
 
     var textArea = element.querySelector('textarea');
-    textArea.classList.add('mojira-helper-messages-textarea');
+    textArea.classList.add(disabled ? 'mojira-helper-messages-textarea-disabled' : 'mojira-helper-messages-textarea');
     textArea.setAttribute('helper-messages-project', project);
 
     if (!addDropdownToWikifield(element, textArea, project, editorCount, disabled)) {

--- a/src/content/dropdown.js
+++ b/src/content/dropdown.js
@@ -56,7 +56,7 @@ function getDropdownList(textArea, project) {
     });
 
     var dropdownList = document.createElement('ul');
-    dropdownList.classList.add('aui-list-truncate', 'helper-messages-dropdown');
+    dropdownList.classList.add('aui-list-truncate', 'mojira-helper-messages-dropdown');
 
     for (item of messageDropdownItems) {
         dropdownList.append(item.element);

--- a/src/content/dropdown.js
+++ b/src/content/dropdown.js
@@ -71,10 +71,11 @@ function getDropdownList(textArea, project) {
  * 
  * @returns {HTMLAnchorElement} The button element
  */
-function getMessageButton(editorCount) {
+function getMessageButton(editorCount, disabled) {
     var messageButtonIcon = document.createElement('span');
     messageButtonIcon.classList.add('aui-icon', 'aui-icon-small', 'aui-iconfont-add-comment');
-    messageButtonIcon.textContent = 'Add Message';
+    const title = disabled ? 'Sorry, you cannot use this here' : 'Add Message';
+    messageButtonIcon.textContent = title;
 
     var messageButton = document.createElement('a');
     messageButton.classList.add(
@@ -85,8 +86,11 @@ function getMessageButton(editorCount) {
         'wiki-edit-messages-trigger',
         'wiki-edit-tooltip'
     );
+    if (disabled) {
+        messageButton.setAttribute('disabled', true);
+    }
     messageButton.href = '#';
-    messageButton.title = 'Add Message';
+    messageButton.title = title;
     messageButton.tabIndex = -1;
     messageButton.setAttribute('aria-controls', `wiki-edit-dropdown2-messages-wikiEdit${editorCount}`);
     messageButton.setAttribute('aria-expanded', false);
@@ -107,21 +111,23 @@ function getMessageButton(editorCount) {
  * 
  * @returns {boolean} Whether the dropdown could be successfully added
  */
-function addDropdownToWikifield(element, textArea, project, editorCount) {
+function addDropdownToWikifield(element, textArea, project, editorCount, disabled) {
     if (element.querySelector('.wiki-edit-toolbar') === null || element.querySelector('.wiki-edit-toolbar-last') === null) {
         return false;
     }
 
-    var dropdownList = getDropdownList(textArea, project);
+    if (!disabled) {
+        var dropdownList = getDropdownList(textArea, project);
 
-    var dropdownElement = document.createElement('div');
-    dropdownElement.classList.add('aui-dropdown2', 'aui-style-default', 'wiki-edit-dropdown');
-    dropdownElement.id = `wiki-edit-dropdown2-messages-wikiEdit${editorCount}`;
-    dropdownElement.append(dropdownList);
+        var dropdownElement = document.createElement('div');
+        dropdownElement.classList.add('aui-dropdown2', 'aui-style-default', 'wiki-edit-dropdown');
+        dropdownElement.id = `wiki-edit-dropdown2-messages-wikiEdit${editorCount}`;
+        dropdownElement.append(dropdownList);
+    
+        element.querySelector('.wiki-edit-toolbar').before(dropdownElement);
+    }
 
-    element.querySelector('.wiki-edit-toolbar').before(dropdownElement);
-
-    var messageButton = getMessageButton(editorCount);
+    var messageButton = getMessageButton(editorCount, disabled);
 
     var messageButtonGroup = document.createElement('div');
     messageButtonGroup.classList.add('aui-buttons');
@@ -138,19 +144,19 @@ function addDropdownToWikifield(element, textArea, project, editorCount) {
  * @param {string} project The project the current ticket is in
  * @param {number} editorCount A unique identifier for this wikifield
  */
-function modifyWikifield(element, project, editorCount) {
+function modifyWikifield(element, project, editorCount, disabled) {
     element.classList.add('mojira-helper-messages-field');
 
     var textArea = element.querySelector('textarea');
     textArea.classList.add('mojira-helper-messages-textarea');
     textArea.setAttribute('helper-messages-project', project);
 
-    if (!addDropdownToWikifield(element, textArea, project, editorCount)) {
+    if (!addDropdownToWikifield(element, textArea, project, editorCount, disabled)) {
         textArea.classList.add('mojira-helper-messages-textarea-shortcut-only');
         
         setTimeout(() => {
             try {
-                if (addDropdownToWikifield(element, textArea, project, editorCount)) {
+                if (addDropdownToWikifield(element, textArea, project, editorCount, disabled)) {
                     textArea.classList.remove('mojira-helper-messages-textarea-shortcut-only');
                 }
             } catch (error) {

--- a/src/content/styling.css
+++ b/src/content/styling.css
@@ -12,7 +12,7 @@
 .mojira-helper-messages-button-disabled {
     cursor: not-allowed !important;
 }
-.helper-messages-dropdown {
+.mojira-helper-messages-dropdown {
     max-height: 250px;
     overflow-y: scroll;
 }

--- a/src/content/styling.css
+++ b/src/content/styling.css
@@ -2,8 +2,15 @@
     border: 1px solid #2ecc72 !important;
     border-radius: 0 !important;
 }
+.mojira-helper-messages-textarea-disabled {
+    border: 1px solid #cc2e2e !important;
+    border-radius: 0 !important;
+}
 .mojira-helper-messages-textarea-shortcut-only {
     border: 1px solid #cc722e !important;
+}
+.mojira-helper-messages-button-disabled {
+    cursor: not-allowed !important;
 }
 .helper-messages-dropdown {
     max-height: 250px;

--- a/src/content/util.js
+++ b/src/content/util.js
@@ -14,3 +14,12 @@ async function sendErrorMessage(error) {
         console.error('Error while reporting error message:', err);
     }
 }
+
+/**
+ * Checks if the currently logged in user is a volunteer user (moderator / helper), only works on issue pages
+ * @returns {Boolean} true if the logged in user is a helper+, false otherwise
+ */
+function isVolunteerUser() {
+    let opsbar = document.querySelector('div#opsbar-opsbar-transitions');
+    return opsbar && opsbar.children.length > 0;
+}


### PR DESCRIPTION
hi, i have created a working implementation for the requirement described in issue #55. 

my implementation disables the "Add Message" button if the extension notices that the currently logged in user is not a helper+. the disabled button looks like this:

![](https://i.bemoty.dev/MbySRL)
(the text "Sorry, you cannot use this here" is a tooltip)

the extension checks whether the button for updating / resolving the open issue is visible / exists. please do note that anyone could bypass this check simply by artificially adding an arbitrary HTML element to the `opsbar-opsbar-transitions` div so that the `document.querySelector('div#opsbar-opsbar-transitions').children.length > 0` check returns `true`. (even though it would probably be easier to just use the online version of the helper messages at this point lol)

if you have any feedback to my implementation please let me know. :)

hope this helps, cheers

